### PR TITLE
Added link to Standard Unix Notes - a GPG encrypted notes/notebook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Taskwarrior](http://taskwarrior.org) - Manage your TODO list from your command-line.
 - [Terminal velocity](https://vhp.github.io/terminal_velocity/) - A fast note-taking app for the terminal.
 - [eureka](https://github.com/simeg/eureka) - Store your ideas without leaving the terminal.
+- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux
 - [sncli](https://github.com/insanum/sncli) - Simplenote client.
 - [td-cli](https://github.com/darrikonn/td-cli) - A todo manager to organize and manage your todos across multiple projects.
 - [taskell](https://github.com/smallhadroncollider/taskell) - Interactive kanban board/task manager.


### PR DESCRIPTION
Hi

I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG.

It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.

<!---
Thank you for your pull request. Please provide below the name of the app, a short description 
and a link to it's repository or homepage. Also, tell us why you think it's awesome!

Make sure the PR adheres to our contribution guidelines:
https://github.com/agarrharr/awesome-cli-apps/blob/master/contributing.md
-->

#### New App Submission

**App name:** 
Standard(?) Unix Notes

**Repo or homepage link:**  
https://github.com/Standard-Unix-Notes/unix-notes

**Description:**
GnuPG encrypted notes system ala 'Password-Store'
Also includes GnuPG journal system

**Why you think it's awesome:**
Simplifies encrypted notetaking and makes it easier to bulk re-encrypt with a new GnuPG key 
